### PR TITLE
Added temporary (hopefully) workaround to photino blazor ignoring url

### DIFF
--- a/src/Strem.Build/Orchestration/DefaultTask.cs
+++ b/src/Strem.Build/Orchestration/DefaultTask.cs
@@ -5,6 +5,7 @@ namespace Strem.Build.Orchestration;
 
 [TaskName("default")]
 [IsDependentOn(typeof(CleanDirectoriesTask))]
+[IsDependentOn(typeof(PackageAppTask))]
 [IsDependentOn(typeof(PackageLibsTask))]
 public class DefaultTask : FrostingTask<BuildContext>
 {

--- a/src/Strem.Build/Tasks/PackageAppTask.cs
+++ b/src/Strem.Build/Tasks/PackageAppTask.cs
@@ -28,6 +28,19 @@ public class PackageAppTask : FrostingTask<BuildContext>
             }
         };
         context.DotNetPublish(appProject, publishSettings);
+        MoveStaticIntoContent(context, outputDirectory);
         context.Zip(outputDirectory, $"{outputDirectory}.zip");
+    }
+
+    public void MoveStaticIntoContent(BuildContext context, string outputDirectory)
+    {
+        // TODO: This is a bodge as for some reason it doesnt do this automatically
+        var wwwroot = $"{outputDirectory}/wwwroot";
+        var stremContent = $"{wwwroot}/_content/Strem";
+        context.CreateDirectory(stremContent);
+        context.CopyFiles($"{wwwroot}/*", $"{stremContent}");
+        context.CopyDirectory($"{wwwroot}/css",$"{stremContent}/css");
+        context.CopyDirectory($"{wwwroot}/js",$"{stremContent}/js");
+        context.CopyDirectory($"{wwwroot}/webfonts",$"{stremContent}/webfonts");
     }
 }

--- a/src/Strem/Application/BlazorBootstrapper.cs
+++ b/src/Strem/Application/BlazorBootstrapper.cs
@@ -16,6 +16,7 @@ public class BlazorBootstrapper
 
     public void SetupWindow(PhotinoBlazorApp app)
     {
+        var rootIndexPage = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot\\_content\\Strem\\index.html");
         var appLauncher = app.MainWindow
             .SetTitle("Strem")
             
@@ -31,9 +32,10 @@ public class BlazorBootstrapper
 #if DEBUG
         appLauncher = appLauncher.SetDevToolsEnabled(true);
 #else
+        appLauncher = appLauncher.SetDevToolsEnabled(false);
         appLauncher = appLauncher.SetContextMenuEnabled(false);
 #endif
-        appLauncher.Load("_content/Strem/wwwroot/index.html");
+        appLauncher.Load(rootIndexPage);
     }
 
     public void SetupApp(Action<IServiceCollection> beforeCreated, Func<PhotinoBlazorApp, Task> afterCreated)


### PR DESCRIPTION
This is crazy and I have raised it on their github issues that it doesnt seem to look where its meant to.

This fix duplicates some files on release but for now its fine.