### PR TITLE
Have added triggers for flow starting/ending

### DIFF
--- a/src/Strem.Flows.Default/Components/Triggers/Utility/OnFlowFinishedTriggerComponent.razor
+++ b/src/Strem.Flows.Default/Components/Triggers/Utility/OnFlowFinishedTriggerComponent.razor
@@ -1,0 +1,27 @@
+﻿@using Strem.Flows.Services.Stores
+@inherits Strem.Flows.Components.Triggers.CustomTriggerComponent<Strem.Flows.Default.Flows.Triggers.Utility.OnFlowFinishedTriggerData>
+
+@inject IFlowStore FlowStore;
+
+<div class="field">
+    <label class="label">Flow</label>
+    <div class="control">
+        <DataSelectInput @bind-Value="Data.FlowId" Data="FlowStore.Data" GetName="x => x.Name" GetValue="x => x.Id" MapValue="x => Guid.Parse(x.ToString())"></DataSelectInput>
+    </div>
+</div>
+<div class="field">
+    <div class="control">
+        <CheckBox @bind-Value="Data.OnlyOnSuccessfulExecution" Label="Only When Finished Successfully?"></CheckBox>
+    </div>
+</div>
+
+@code {
+    public override string Title => GetTitle();
+
+    public string GetTitle()
+    {
+        var targetedFlow = FlowStore.Get(Data.FlowId);
+        var successfulSuffix = Data.OnlyOnSuccessfulExecution ? "Successfully" : "";
+        return $"On <strong>{targetedFlow?.Name ?? "Flow"}</strong> Finished {successfulSuffix}";
+    }
+}

--- a/src/Strem.Flows.Default/Components/Triggers/Utility/OnFlowStartedTriggerComponent.razor
+++ b/src/Strem.Flows.Default/Components/Triggers/Utility/OnFlowStartedTriggerComponent.razor
@@ -1,0 +1,21 @@
+﻿@using Strem.Flows.Services.Stores
+@inherits Strem.Flows.Components.Triggers.CustomTriggerComponent<Strem.Flows.Default.Flows.Triggers.Utility.OnFlowStartedTriggerData>
+
+@inject IFlowStore FlowStore;
+
+<div class="field">
+    <label class="label">Flow</label>
+    <div class="control">
+        <DataSelectInput @bind-Value="Data.FlowId" Data="FlowStore.Data" GetName="x => x.Name" GetValue="x => x.Id" MapValue="x => Guid.Parse(x.ToString())"></DataSelectInput>
+    </div>
+</div>
+
+@code {
+    public override string Title => GetTitle();
+
+    public string GetTitle()
+    {
+        var targetedFlow = FlowStore.Get(Data.FlowId);
+        return $"On <strong>{targetedFlow?.Name ?? "Flow"}</strong> Starting";
+    }
+}

--- a/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowFinishedTrigger.cs
+++ b/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowFinishedTrigger.cs
@@ -1,0 +1,57 @@
+﻿using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
+using Strem.Core.Events.Bus;
+using Strem.Core.Extensions;
+using Strem.Core.State;
+using Strem.Core.Variables;
+using Strem.Flows.Data.Triggers;
+using Strem.Flows.Events;
+using Strem.Flows.Processors;
+using Strem.Flows.Services.Stores;
+using Strem.Flows.Types;
+
+namespace Strem.Flows.Default.Flows.Triggers.Utility;
+
+public class OnFlowFinishedTrigger : FlowTrigger<OnFlowFinishedTriggerData>
+{
+    public override string Code => OnFlowFinishedTriggerData.TriggerCode;
+    public override string Version => OnFlowFinishedTriggerData.TriggerVersion;
+
+    public static VariableEntry FlowNameVariableEntry = new("flow.name");
+
+    public override string Name => "On Flow Finished";
+    public override string Category => "Utility";
+    public override string Description => "Triggers whenever the matching flow has finished executing";
+    public override VariableDescriptor[] VariableOutputs { get; } = new[] { FlowNameVariableEntry.ToDescriptor() };
+
+    public IFlowStore FlowStore { get; }
+    
+    public OnFlowFinishedTrigger(ILogger<FlowTrigger<OnFlowFinishedTriggerData>> logger, IFlowStringProcessor flowStringProcessor, IAppState appState, IEventBus eventBus, IFlowStore flowStore) : base(logger, flowStringProcessor, appState, eventBus)
+    {
+        FlowStore = flowStore;
+    }
+
+    public override bool CanExecute() => true;
+
+    public override async Task<IObservable<IVariables>> Execute(OnFlowFinishedTriggerData data)
+    {
+        return EventBus.Receive<FlowFinishedEvent>()
+            .Where(x => x.FlowId == data.FlowId)
+            .Where(x => MatchesExecutionState(x, data))
+            .Select(x =>
+            {
+                var newVariables = new Core.Variables.Variables();
+                var flow = FlowStore.Get(x.FlowId);
+                newVariables.Set(FlowNameVariableEntry, flow!.Name);
+                return newVariables;
+            });
+    }
+
+    private bool MatchesExecutionState(FlowFinishedEvent eventData, OnFlowFinishedTriggerData flowData)
+    {
+        if (flowData.OnlyOnSuccessfulExecution)
+        { return eventData.executionResultType is ExecutionResultType.Success or ExecutionResultType.FailedButContinue; }
+
+        return true;
+    }
+}

--- a/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowFinishedTrigger.cs
+++ b/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowFinishedTrigger.cs
@@ -50,7 +50,7 @@ public class OnFlowFinishedTrigger : FlowTrigger<OnFlowFinishedTriggerData>
     private bool MatchesExecutionState(FlowFinishedEvent eventData, OnFlowFinishedTriggerData flowData)
     {
         if (flowData.OnlyOnSuccessfulExecution)
-        { return eventData.executionResultType is ExecutionResultType.Success or ExecutionResultType.FailedButContinue; }
+        { return eventData.ExecutionResultType is ExecutionResultType.Success or ExecutionResultType.FailedButContinue; }
 
         return true;
     }

--- a/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowFinishedTriggerData.cs
+++ b/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowFinishedTriggerData.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Strem.Flows.Data.Triggers;
+
+namespace Strem.Flows.Default.Flows.Triggers.Utility;
+
+public class OnFlowFinishedTriggerData : IFlowTriggerData
+{
+    public static readonly string TriggerCode = "on-flow-finished";
+    public static readonly string TriggerVersion = "1.0.0";
+    
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Code => TriggerCode;
+    public string Version { get; set; } = TriggerVersion;
+    
+    [Required]
+    public Guid FlowId { get; set; }
+
+    public bool OnlyOnSuccessfulExecution { get; set; } = true;
+}

--- a/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowStartedTrigger.cs
+++ b/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowStartedTrigger.cs
@@ -1,0 +1,47 @@
+﻿using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
+using Strem.Core.Events.Bus;
+using Strem.Core.Extensions;
+using Strem.Core.State;
+using Strem.Core.Variables;
+using Strem.Flows.Data.Triggers;
+using Strem.Flows.Events;
+using Strem.Flows.Processors;
+using Strem.Flows.Services.Stores;
+
+namespace Strem.Flows.Default.Flows.Triggers.Utility;
+
+public class OnFlowStartedTrigger : FlowTrigger<OnFlowStartedTriggerData>
+{
+    public override string Code => OnFlowStartedTriggerData.TriggerCode;
+    public override string Version => OnFlowStartedTriggerData.TriggerVersion;
+
+    public static VariableEntry FlowNameVariableEntry = new("flow.name");
+
+    public override string Name => "On Flow Started";
+    public override string Category => "Utility";
+    public override string Description => "Triggers when the matching flow starts executing";
+    public override VariableDescriptor[] VariableOutputs { get; } = new[] { FlowNameVariableEntry.ToDescriptor() };
+
+    public IFlowStore FlowStore { get; }
+    
+    public OnFlowStartedTrigger(ILogger<FlowTrigger<OnFlowStartedTriggerData>> logger, IFlowStringProcessor flowStringProcessor, IAppState appState, IEventBus eventBus, IFlowStore flowStore) : base(logger, flowStringProcessor, appState, eventBus)
+    {
+        FlowStore = flowStore;
+    }
+
+    public override bool CanExecute() => true;
+
+    public override async Task<IObservable<IVariables>> Execute(OnFlowStartedTriggerData data)
+    {
+        return EventBus.Receive<FlowStartedEvent>()
+            .Where(x => x.FlowId == data.FlowId)
+            .Select(x =>
+            {
+                var newVariables = new Core.Variables.Variables();
+                var flow = FlowStore.Get(x.FlowId);
+                newVariables.Set(FlowNameVariableEntry, flow!.Name);
+                return newVariables;
+            });
+    }
+}

--- a/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowStartedTriggerData.cs
+++ b/src/Strem.Flows.Default/Flows/Triggers/Utility/OnFlowStartedTriggerData.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Strem.Flows.Data.Triggers;
+
+namespace Strem.Flows.Default.Flows.Triggers.Utility;
+
+public class OnFlowStartedTriggerData : IFlowTriggerData
+{
+    public static readonly string TriggerCode = "on-flow-started";
+    public static readonly string TriggerVersion = "1.0.0";
+    
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Code => TriggerCode;
+    public string Version { get; set; } = TriggerVersion;
+    
+    [Required]
+    public Guid FlowId { get; set; }
+}

--- a/src/Strem.Flows.Default/Strem.Flows.Default.csproj
+++ b/src/Strem.Flows.Default/Strem.Flows.Default.csproj
@@ -34,6 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <AdditionalFiles Include="Components\Triggers\Utility\OnFlowStartedTriggerComponent.razor" />
       <AdditionalFiles Include="Pages\Flows.razor" />
     </ItemGroup>
 

--- a/src/Strem.Flows.Default/Strem.Flows.Default.csproj
+++ b/src/Strem.Flows.Default/Strem.Flows.Default.csproj
@@ -33,9 +33,4 @@
       <ProjectReference Include="..\Strem.Infrastructure\Strem.Infrastructure.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <AdditionalFiles Include="Components\Triggers\Utility\OnFlowStartedTriggerComponent.razor" />
-      <AdditionalFiles Include="Pages\Flows.razor" />
-    </ItemGroup>
-
 </Project>

--- a/src/Strem.Flows/Events/FlowFinishedEvent.cs
+++ b/src/Strem.Flows/Events/FlowFinishedEvent.cs
@@ -1,5 +1,6 @@
 ﻿using Strem.Flows.Events.Base;
+using Strem.Flows.Types;
 
 namespace Strem.Flows.Events;
 
-public record FlowFinishedEvent(Guid FlowId) : FlowEvent(FlowId);
+public record FlowFinishedEvent(Guid FlowId, ExecutionResultType executionResultType) : FlowEvent(FlowId);

--- a/src/Strem.Flows/Events/FlowFinishedEvent.cs
+++ b/src/Strem.Flows/Events/FlowFinishedEvent.cs
@@ -3,4 +3,4 @@ using Strem.Flows.Types;
 
 namespace Strem.Flows.Events;
 
-public record FlowFinishedEvent(Guid FlowId, ExecutionResultType executionResultType) : FlowEvent(FlowId);
+public record FlowFinishedEvent(Guid FlowId, ExecutionResultType ExecutionResultType) : FlowEvent(FlowId);

--- a/src/Strem.Flows/Executors/FlowExecutionEngine.cs
+++ b/src/Strem.Flows/Executors/FlowExecutionEngine.cs
@@ -95,7 +95,7 @@ public class FlowExecutionEngine : IFlowExecutionEngine
     
     public void FinishFlow(Flow flow, ExecutionResultType executionResultType, IVariables flowVariables, FlowExecutionLog executionLog, IFlowTaskData? currentTaskData = null)
     {
-        EventBus.PublishAsync(new FlowFinishedEvent(flow.Id));
+        EventBus.PublishAsync(new FlowFinishedEvent(flow.Id, executionResultType));
         FlowExecutionLogger.CloseLogFor(executionLog, flowVariables, executionResultType, currentTaskData);
     }
 


### PR DESCRIPTION
This should support use cases where you want sequential execution over flow boundries without using events.