### PR TITLE
Chore/update dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Run Build Script
         shell: pwsh
         run: |
-          ./build.ps1 --buildNo='0.9.${{github.run_number}}' --target='build-and-test'
+          ./build.ps1 --buildNo='0.10.${{github.run_number}}' --target='build-and-test'
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Package App Script
         shell: pwsh
-        run: ./build.ps1 --buildNo='0.9.${{github.run_number}}' --target='publish'
+        run: ./build.ps1 --buildNo='0.10.${{github.run_number}}' --target='publish'
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET 8.0
+      - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Run Build Script
         shell: pwsh
         run: |

--- a/src/Strem.Build/Strem.Build.csproj
+++ b/src/Strem.Build/Strem.Build.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Strem.Build/Strem.Build.csproj
+++ b/src/Strem.Build/Strem.Build.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="Cake.Coverlet" Version="2.5.4" />
       <PackageReference Include="Cake.Frosting" Version="2.2.0" />
       <PackageReference Include="Glob" Version="1.1.9" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Strem.Core/Events/Broker/MessageBroker.cs
+++ b/src/Strem.Core/Events/Broker/MessageBroker.cs
@@ -9,7 +9,7 @@ public class MessageBroker : IMessageBroker, IDisposable
 
     public void Publish<T>(T message)
     {
-        object notifier;
+        object? notifier;
         lock (_notifiers)
         {
             if (_isDisposed) { return; }

--- a/src/Strem.Core/Services/Browsers/File/IFileBrowser.cs
+++ b/src/Strem.Core/Services/Browsers/File/IFileBrowser.cs
@@ -2,6 +2,6 @@
 
 public interface IFileBrowser
 {
-    string BrowseToOpenFile(string startingDirectory = null, string filterList = null);
-    string BrowseToSaveFile(string startingDirectory = null, string filterList = null);
+    string BrowseToOpenFile(string? startingDirectory = null, string? filterList = null);
+    string BrowseToSaveFile(string? startingDirectory = null, string? filterList = null);
 }

--- a/src/Strem.Core/Services/Validation/Attributes/IsFloatAttribute.cs
+++ b/src/Strem.Core/Services/Validation/Attributes/IsFloatAttribute.cs
@@ -4,7 +4,7 @@ namespace Strem.Core.Services.Validation.Attributes;
 
 public class IsFloatAttribute : ValidationAttribute
 {
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
     {
         if (value == null) { return ValidationResult.Success;}
         

--- a/src/Strem.Core/Strem.Core.csproj
+++ b/src/Strem.Core/Strem.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="SharpHook.Reactive" Version="5.3.1" />
       <PackageReference Include="System.Reactive" Version="6.0.0" />

--- a/src/Strem.Core/Strem.Core.csproj
+++ b/src/Strem.Core/Strem.Core.csproj
@@ -14,8 +14,8 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="SharpHook.Reactive" Version="5.3.1" />
-      <PackageReference Include="System.Reactive" Version="6.0.0" />
+      <PackageReference Include="SharpHook.Reactive" Version="5.3.8" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
     
 </Project>

--- a/src/Strem.Core/Variables/Variables.cs
+++ b/src/Strem.Core/Variables/Variables.cs
@@ -14,7 +14,7 @@ public class Variables : IVariables
     [JsonIgnore]
     public IObservable<KeyValuePair<VariableEntry, string>> OnVariableChanged => OnChangedSubject;
    
-    public Variables(Dictionary<VariableEntry, string> state = null)
+    public Variables(Dictionary<VariableEntry, string>? state = null)
     { Data = state ?? new Dictionary<VariableEntry, string>(); }
 
     public VariableEntry FindFullyQualifiedEntry(string variableName)

--- a/src/Strem.Data/Strem.Data.csproj
+++ b/src/Strem.Data/Strem.Data.csproj
@@ -10,7 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="LiteDB" Version="5.0.19" />
+      <PackageReference Include="LiteDB" Version="5.0.21" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Data/Strem.Data.csproj
+++ b/src/Strem.Data/Strem.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>

--- a/src/Strem.Flows.Default/Strem.Flows.Default.csproj
+++ b/src/Strem.Flows.Default/Strem.Flows.Default.csproj
@@ -16,13 +16,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BlazorMonaco" Version="3.1.0" />
-        <PackageReference Include="IronPython" Version="3.4.1" />
+        <PackageReference Include="BlazorMonaco" Version="3.3.0" />
+        <PackageReference Include="IronPython" Version="3.4.2" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
-        <PackageReference Include="RestSharp" Version="108.0.3" />
-        <PackageReference Include="SharpHook.Reactive" Version="5.3.1" />
-        <PackageReference Include="Westwind.Scripting" Version="1.4.1" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
+        <PackageReference Include="RestSharp" Version="112.1.0" />
+        <PackageReference Include="SharpHook.Reactive" Version="5.3.8" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
+        <PackageReference Include="Westwind.Scripting" Version="1.5.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Flows.Default/Strem.Flows.Default.csproj
+++ b/src/Strem.Flows.Default/Strem.Flows.Default.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <OutputType>Library</OutputType>
@@ -18,9 +18,9 @@
     <ItemGroup>
         <PackageReference Include="BlazorMonaco" Version="3.1.0" />
         <PackageReference Include="IronPython" Version="3.4.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
-        <PackageReference Include="RestSharp" Version="108.0.1" />
+        <PackageReference Include="RestSharp" Version="108.0.3" />
         <PackageReference Include="SharpHook.Reactive" Version="5.3.1" />
         <PackageReference Include="Westwind.Scripting" Version="1.4.1" />
     </ItemGroup>

--- a/src/Strem.Flows/Strem.Flows.csproj
+++ b/src/Strem.Flows/Strem.Flows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="System.Reactive" Version="6.0.0" />
     </ItemGroup>

--- a/src/Strem.Flows/Strem.Flows.csproj
+++ b/src/Strem.Flows/Strem.Flows.csproj
@@ -14,7 +14,7 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="System.Reactive" Version="6.0.0" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Infrastructure/Strem.Infrastructure.csproj
+++ b/src/Strem.Infrastructure/Strem.Infrastructure.csproj
@@ -18,12 +18,13 @@
 
     <ItemGroup>
       <PackageReference Include="Glob" Version="1.1.9" />
-      <PackageReference Include="LiteDB" Version="5.0.19" />
+      <PackageReference Include="LiteDB" Version="5.0.21" />
       <PackageReference Include="Persistity.Flow" Version="2.0.47" />
       <PackageReference Include="Persistity.Serializers.Json" Version="2.0.47" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Infrastructure/Strem.Infrastructure.csproj
+++ b/src/Strem.Infrastructure/Strem.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>

--- a/src/Strem.OBS/Strem.OBS.csproj
+++ b/src/Strem.OBS/Strem.OBS.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
         <PackageReference Include="Obs.v5.WebSocket.Reactive" Version="1.0.11" />
         <PackageReference Include="Persistity" Version="2.0.47" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.OBS/Strem.OBS.csproj
+++ b/src/Strem.OBS/Strem.OBS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>12</LangVersion>
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
         <PackageReference Include="Obs.v5.WebSocket.Reactive" Version="1.0.11" />
         <PackageReference Include="Persistity" Version="2.0.47" />
     </ItemGroup>

--- a/src/Strem.Platforms.Windows/Strem.Platforms.Windows.csproj
+++ b/src/Strem.Platforms.Windows/Strem.Platforms.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Strem.Platforms.Windows/Strem.Platforms.Windows.csproj
+++ b/src/Strem.Platforms.Windows/Strem.Platforms.Windows.csproj
@@ -10,7 +10,8 @@
 
     <ItemGroup>
       <PackageReference Include="NAudio" Version="2.2.1" />
-      <PackageReference Include="System.Speech" Version="8.0.0" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
+      <PackageReference Include="System.Speech" Version="9.0.0" />
       <PackageReference Include="TextCopy" Version="6.2.1" />
     </ItemGroup>
 

--- a/src/Strem.Portals/Components/App/PortalCreator.razor
+++ b/src/Strem.Portals/Components/App/PortalCreator.razor
@@ -40,9 +40,9 @@
 
     public void Create()
     {
-        var newFlow = new PortalData(Guid.NewGuid(), Data.Name);
+        var newPortal = new PortalData(Guid.NewGuid(), Data.Name);
         Data.Name = string.Empty;
-        OnPortalCreated.InvokeAsync(newFlow);
+        OnPortalCreated.InvokeAsync(newPortal);
     }
 
     public void Cancel()

--- a/src/Strem.Portals/Components/App/UserPortals.razor
+++ b/src/Strem.Portals/Components/App/UserPortals.razor
@@ -1,12 +1,11 @@
 ﻿@using Strem.Core.Extensions
-@using Strem.Core.Events.Bus
 @using System.Reactive.Disposables
 @using Strem.Core.Services.Browsers.File
 @using Strem.Core.Services.UI.Modal
 @using Strem.Core.Services.UI.Notifications
-@using Strem.Flows.Services.Data
 @using Strem.Portals.Data
-@using Strem.Portals.Events
+@using Strem.Portals.Data.Overrides
+@using Strem.Portals.Extensions
 @using Strem.Portals.Services.Data
 @using Strem.Portals.Services.Stores
 
@@ -15,6 +14,7 @@
 @inject IFileBrowser FileBrowser;
 @inject IPortalImporter PortalImporter;
 @inject IPortalExporter PortalExporter;
+@inject GridElementRuntimeStyles GridElementRuntimeStyles 
 
 @implements IDisposable
 
@@ -119,6 +119,8 @@
   public void OnPortalCreated(PortalData newPortal)
   {
     PortalStore.Add(newPortal);
+    GridElementRuntimeStyles.RefreshStylesFor(newPortal);
+    
     SelectPortal(newPortal);
     ModalService.CloseModal();
   }

--- a/src/Strem.Portals/Components/Client/PortalViewer.razor
+++ b/src/Strem.Portals/Components/Client/PortalViewer.razor
@@ -224,7 +224,7 @@
     public async Task NotifyButtonPressed(GridElementData gridElementData)
     {
         EventBus.PublishAsync(new PortalElementPressedEvent(Portal.Id, Portal.Name, gridElementData.Id, gridElementData.Name));
-        await Js.InvokeVoidAsync("animateElementById", gridElementData.Id, "heartBeat");
+        await Js.InvokeVoidAsync("animateElementById", gridElementData.Id, "pulse", "1s");
     }
     
     public void NotifySliderValueChanged(GridElementData gridElementData, int value)

--- a/src/Strem.Portals/Extensions/ButtonRuntimeStylesExtensions.cs
+++ b/src/Strem.Portals/Extensions/ButtonRuntimeStylesExtensions.cs
@@ -18,15 +18,24 @@ public static class ButtonRuntimeStylesExtensions
         return buttonRuntimeStyles;
     }
     
+    public static void RefreshStylesFor(this GridElementRuntimeStyles styles, PortalData portalData)
+    {
+        if (!styles.RuntimeStyles.ContainsKey(portalData.Id))
+        { styles.RuntimeStyles.Add(portalData.Id, new Dictionary<Guid, ElementStyles>()); }
+
+        var portalRuntimeStyles = styles.RuntimeStyles[portalData.Id];
+        portalRuntimeStyles.Clear();
+
+        foreach (var elementData in portalData.Elements)
+        { portalRuntimeStyles.Add(elementData.Id, new ElementStyles(elementData.DefaultStyles)); }
+    }
+    
     public static void RefreshStylesFor(this GridElementRuntimeStyles styles, Guid portalId, GridElementData gridElement)
     {
         if(!styles.RuntimeStyles.ContainsKey(portalId))
-        { return; }
+        { styles.RuntimeStyles.Add(portalId, new Dictionary<Guid, ElementStyles>()); }
 
         var portalStyles = styles.RuntimeStyles[portalId];
-        if(!portalStyles.ContainsKey(gridElement.Id))
-        { return; }
-
         portalStyles[gridElement.Id] = new ElementStyles(gridElement.DefaultStyles);
     }
     

--- a/src/Strem.Portals/Strem.Portals.csproj
+++ b/src/Strem.Portals/Strem.Portals.csproj
@@ -7,7 +7,7 @@
         <Version>0.0.0</Version>
         <IsPackable>true</IsPackable>
         <LangVersion>12</LangVersion>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
 
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Portals/Strem.Portals.csproj
+++ b/src/Strem.Portals/Strem.Portals.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.StreamElements/Strem.StreamElements.csproj
+++ b/src/Strem.StreamElements/Strem.StreamElements.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <Version>0.0.0</Version>
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="StreamElements.WebSocket.Reactive" Version="1.0.2" />
     </ItemGroup>

--- a/src/Strem.StreamElements/Strem.StreamElements.csproj
+++ b/src/Strem.StreamElements/Strem.StreamElements.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="StreamElements.WebSocket.Reactive" Version="1.0.2" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Todos/Strem.Todos.csproj
+++ b/src/Strem.Todos/Strem.Todos.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>true</IsPackable>
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Todos/Strem.Todos.csproj
+++ b/src/Strem.Todos/Strem.Todos.csproj
@@ -15,6 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.Twitch/Strem.Twitch.csproj
+++ b/src/Strem.Twitch/Strem.Twitch.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="RestSharp" Version="108.0.3" />
-      <PackageReference Include="System.Reactive" Version="6.0.0" />
+      <PackageReference Include="RestSharp" Version="112.1.0" />
+      <PackageReference Include="System.Reactive" Version="6.0.1" />
       <PackageReference Include="TwitchLib" Version="3.5.3" />
     </ItemGroup>
 

--- a/src/Strem.Twitch/Strem.Twitch.csproj
+++ b/src/Strem.Twitch/Strem.Twitch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
@@ -12,7 +12,7 @@
 
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="RestSharp" Version="108.0.1" />
+      <PackageReference Include="RestSharp" Version="108.0.3" />
       <PackageReference Include="System.Reactive" Version="6.0.0" />
       <PackageReference Include="TwitchLib" Version="3.5.3" />
     </ItemGroup>

--- a/src/Strem.UI/Strem.UI.csproj
+++ b/src/Strem.UI/Strem.UI.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>12</LangVersion>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RestSharp" Version="108.0.1" />
+        <PackageReference Include="RestSharp" Version="108.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.UI/Strem.UI.csproj
+++ b/src/Strem.UI/Strem.UI.csproj
@@ -8,7 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RestSharp" Version="108.0.3" />
+        <PackageReference Include="RestSharp" Version="112.1.0" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Strem.UnitTests/Strem.UnitTests.csproj
+++ b/src/Strem.UnitTests/Strem.UnitTests.csproj
@@ -12,14 +12,18 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Strem.UnitTests/Strem.UnitTests.csproj
+++ b/src/Strem.UnitTests/Strem.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Strem/Application/BlazorBootstrapper.cs
+++ b/src/Strem/Application/BlazorBootstrapper.cs
@@ -19,6 +19,7 @@ public class BlazorBootstrapper
     {
         var appLauncher = app.MainWindow
             .SetTitle("Strem")
+            .SetJavascriptClipboardAccessEnabled(true)
             
 #if DEBUG
             .SetLogVerbosity(3)

--- a/src/Strem/Application/BlazorBootstrapper.cs
+++ b/src/Strem/Application/BlazorBootstrapper.cs
@@ -17,7 +17,6 @@ public class BlazorBootstrapper
 
     public void SetupWindow(PhotinoBlazorApp app)
     {
-        var rootIndexPage = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot\\_content\\Strem\\index.html");
         var appLauncher = app.MainWindow
             .SetTitle("Strem")
             

--- a/src/Strem/Strem.csproj
+++ b/src/Strem/Strem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <Version>0.0.0</Version>
@@ -20,7 +20,7 @@
 
     <ItemGroup>
         <PackageReference Include="BlazorMonaco" Version="3.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="9.0.0" />
         <PackageReference Include="Photino.Blazor" Version="2.7.0" />
         <PackageReference Include="System.Reactive" Version="6.0.0" />
     </ItemGroup>

--- a/src/Strem/Strem.csproj
+++ b/src/Strem/Strem.csproj
@@ -19,10 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BlazorMonaco" Version="3.1.0" />
+        <PackageReference Include="BlazorMonaco" Version="3.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="9.0.0" />
-        <PackageReference Include="Photino.Blazor" Version="2.7.0" />
-        <PackageReference Include="System.Reactive" Version="6.0.0" />
+        <PackageReference Include="Photino.Blazor" Version="3.2.0" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Strem/Strem.csproj
+++ b/src/Strem/Strem.csproj
@@ -9,6 +9,10 @@
         <ApplicationIcon>strem.ico</ApplicationIcon>
         <IsPackable>false</IsPackable>
         <LangVersion>12</LangVersion>
+        <WasmFingerprintAssets>false</WasmFingerprintAssets>
+        <StaticWebAssetFingerprintingEnabled>false</StaticWebAssetFingerprintingEnabled>
+        <StaticWebAssetsFingerprintContent>false</StaticWebAssetsFingerprintContent>
+        <DisableBuildCompression>true</DisableBuildCompression>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/src/Strem/wwwroot/js/interop-methods.js
+++ b/src/Strem/wwwroot/js/interop-methods.js
@@ -72,16 +72,18 @@ function showNotification(text, type, duration)
     bulmaToast.toast({ message: text, type: type, duration: duration });
 }
 
-function animateElement(element, animation, prefix = 'animate__') {
+function animateElement(element, animation, duration = '1s', prefix = 'animate__') {
     // We create a Promise and return it
     new Promise((resolve, reject) => {
         const animationName = `${prefix}${animation}`;
+        element.style.setProperty('--animate-duration', duration);
         element.classList.add(`${prefix}animated`, animationName);
-        
+                
         // When the animation ends, we clean the classes and resolve the Promise
         function handleAnimationEnd(event) {
             event.stopPropagation();
             element.classList.remove(`${prefix}animated`, animationName);
+            element.style.removeProperty(`--animate-duration`);
             resolve('Animation ended');
         }
         
@@ -89,9 +91,9 @@ function animateElement(element, animation, prefix = 'animate__') {
     });
 }
 
-function animateElementById(elementId, animation, prefix = 'animate__') {
+function animateElementById(elementId, animation, duration = '1s', prefix = 'animate__') {
     const element = document.getElementById(elementId);
-    animateElement(element, animation, prefix);
+    animateElement(element, animation, duration, prefix);
 }
 
 function setNoSleepButton(element) {

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Updated to .net 9 as well as updating dependencies, included a minor fix for runtime style caches for portals as part of this too.